### PR TITLE
changed rainbow furnace linked count check

### DIFF
--- a/src/main/java/ironfurnaces/tileentity/furnaces/BlockIronFurnaceTileBase.java
+++ b/src/main/java/ironfurnaces/tileentity/furnaces/BlockIronFurnaceTileBase.java
@@ -584,7 +584,7 @@ public abstract class BlockIronFurnaceTileBase extends TileEntityInventory imple
                 }
 
 
-                if (furnaceTile.furnaces.size() == Config.millionFurnacePower.get()) {
+                if (furnaceTile.furnaces.size() >= Config.millionFurnacePower.get()) {
                     for (BlockIronFurnaceTileBase furnace : furnaceTile.furnaces) {
                         level.getChunkAt(furnace.getBlockPos()).setLoaded(true);
                         if (furnace.generatorBurn <= 0 || furnace.getEnergy() >= furnace.getCapacity()) {


### PR DESCRIPTION
changed check from "equal to" to "greater than or equal to", preventing infinite power if more furnaces are available than required