### PR TITLE
Remove leading whitespace in UpdateChecker's Thread name

### DIFF
--- a/src/main/java/ironfurnaces/update/ThreadUpdateChecker.java
+++ b/src/main/java/ironfurnaces/update/ThreadUpdateChecker.java
@@ -15,7 +15,7 @@ import java.util.Properties;
 public class ThreadUpdateChecker extends Thread {
 
     public ThreadUpdateChecker() {
-        this.setName(" Iron Furnaces Update Checker");
+        this.setName("Iron Furnaces Update Checker");
         this.setDaemon(true);
         this.start();
     }


### PR DESCRIPTION
I believe this was accidentally added, looks kinda ugly in the logs 😛 

![image](https://github.com/Qelifern/IronFurnaces/assets/4926869/298a8f48-1276-4516-b821-fb513e6981d1)
